### PR TITLE
Use `isResizable` value in ThComponent classname

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -365,7 +365,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
           key={i + '-' + column.id}
           className={classnames(
             classes,
-            'rt-resizable-header',
+            isResizable && 'rt-resizable-header',
             sort ? (sort.desc ? '-sort-desc' : '-sort-asc') : '',
             isSortable && '-cursor-pointer',
             !show && '-hidden',
@@ -384,7 +384,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
           }}
           {...rest}
         >
-          <div className='rt-resizable-header-content'>
+          <div className={classnames(isResizable && 'rt-resizable-header-content')}>
             {_.normalizeComponent(column.Header, {
               data: sortedData,
               column: column,


### PR DESCRIPTION
Pretty tiny tweak, but I presume this is the "expected behavior".

Currently, passing `resizable` will add or not add the resizing components (index L354). But the `'rt-resizable-header'` classname is always added.

This change will only add the `'rt-resizable-header'` if `resizable` is `true`.

Similarly on in child div inside the `<ThComponent>`.