### PR TITLE
Make the css for input and select more specific

### DIFF
--- a/src/index.styl
+++ b/src/index.styl
@@ -195,6 +195,16 @@ $expandSize = 7px
     box-shadow: 0 0px 15px 0px alpha(black, .1)
     border-top: 2px solid alpha(black, .1)
 
+    input
+    select
+      border: 1px solid rgba(0,0,0,0.1)
+      background: white
+      padding: 5px 7px
+      font-size: inherit
+      border-radius: 3px
+      font-weight: normal
+      outline:none
+
     .-btn
       appearance:none
       display:block
@@ -291,16 +301,6 @@ $expandSize = 7px
       pointer-events: all
       > div
         transform: translateY(50%)
-
-  input
-  select
-    border: 1px solid rgba(0,0,0,0.1)
-    background: white
-    padding: 5px 7px
-    font-size: inherit
-    border-radius: 3px
-    font-weight: normal
-    outline:none
 
   .rt-resizing
     .rt-th


### PR DESCRIPTION
The current css selectors, eg. `.ReactTable input` cause conflicts with `input` elements inside Cells. So changed it to `.ReactTable .-pagination input`.