### PR TITLE
Fixed README's Fully Controlled Component filtered

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ Here are the props and their corresponding callbacks that control the state of t
       3: true
     }
   }}
-  filters={[{ // the current filters model
+  filtered={[{ // the current filters model
     id: 'lastName',
     value: 'linsley'
   }]}


### PR DESCRIPTION
In README's Fully Controlled Component section current filters model is assigned to `filters` property which does not work. It should be assigned to `filtered`.