### PR TITLE
make rt-tfoot flex behaviour the same as rt-thead

### DIFF
--- a/src/index.styl
+++ b/src/index.styl
@@ -168,6 +168,7 @@ $expandSize = 7px
     z-index: 10
 
   .rt-tfoot
+    flex: 1 0 auto
     display: flex
     flex-direction: column
     box-shadow: 0 0px 15px 0px alpha(black, .15)


### PR DESCRIPTION
This brings `rt-tfoot` into line with `rt-thead` in terms of flex behaviour.
Without this, it's possible for an `rt-tr` to be taller than its containing
`rt-tfoot` without causing it to expand, which causes the outer `rt-table` to
scroll vertically.