### PR TITLE
Supply sort direction to custom sort methods (#476)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ These are all of the available props (and their default values) for the main `<R
     const id = filter.pivotId || filter.id
     return row[id] !== undefined ? String(row[id]).startsWith(filter.value) : true
   },
-  defaultSortMethod: (a, b) => {
+  defaultSortMethod: (a, b, desc) => {
     // force null and undefined to the bottom
     a = (a === null || a === undefined) ? -Infinity : a
     b = (b === null || b === undefined) ? -Infinity : b
@@ -837,9 +837,9 @@ To override the sorting algorithm for a single column, use the `sortMethod` colu
 Supply a function that implements the native javascript [`Array.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) interface. This is React Table's default sorting algorithm:
 - `a` the first value to compare
 - `b` the second value to compare
-- `dir` the
+- `desc` true if sort is descending, false if ascending
 ```javascript
-defaultSortMethod = (a, b) => {
+defaultSortMethod = (a, b, desc) => {
   // force null and undefined to the bottom
   a = (a === null || a === undefined) ? -Infinity : a
   b = (b === null || b === undefined) ? -Infinity : b

--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -35,7 +35,7 @@ export default {
       ? String(row[id]).startsWith(filter.value)
       : true
   },
-  defaultSortMethod: (a, b) => {
+  defaultSortMethod: (a, b, desc) => {
     // force null and undefined to the bottom
     a = a === null || a === undefined ? '' : a
     b = b === null || b === undefined ? '' : b

--- a/src/methods.js
+++ b/src/methods.js
@@ -412,11 +412,11 @@ export default Base =>
           // Support custom sorting methods for each column
           if (sortMethodsByColumnID[sort.id]) {
             return (a, b) => {
-              return sortMethodsByColumnID[sort.id](a[sort.id], b[sort.id])
+              return sortMethodsByColumnID[sort.id](a[sort.id], b[sort.id], sort.desc)
             }
           }
           return (a, b) => {
-            return this.props.defaultSortMethod(a[sort.id], b[sort.id])
+            return this.props.defaultSortMethod(a[sort.id], b[sort.id], sort.desc)
           }
         }),
         sorted.map(d => !d.desc),


### PR DESCRIPTION
It's sometimes desirable to modify your sort method based on the direction of sort, for example in order to always sort null/undefined to the bottom of the table. This can be achieved simply by passing the direction of sort to the sort method, and doesn't change the default behaviour. The docs had a curious reference to "dir", which might have been intended for this, but the code doesn't reflect that.