### PR TITLE
Expose page/pageSize to rows/cells

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -501,6 +501,8 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
         row: row,
         index: row[indexKey],
         viewIndex: ++rowIndex,
+        pageSize: pageSize,
+        page: page,
         level: path.length,
         nestingPath: path.concat([i]),
         aggregated: row[aggregatedKey],


### PR DESCRIPTION
I needed my Cell functions to know what page/pageSize was being displayed (to do some custom numbering based on the current page) and couldn't find any way to access that info. This PR exposes those two items to the rows/cells.