### PR TITLE
Passes sorting state as props to Th components

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,9 @@ These are all of the available props (and their default values) for the main `<R
   getTheadGroupThProps: () => ({}),
   getTheadProps: () => ({}),
   getTheadTrProps: () => ({}),
-  getTheadThProps: () => ({}),
+  getTheadThProps: ({ sorted }, rowInfo, column) => ({
+    sorted: sorted.find(col => col.id === column.id)
+  }),
   getTheadFilterProps: () => ({}),
   getTheadFilterTrProps: () => ({}),
   getTheadFilterThProps: () => ({}),

--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -97,7 +97,9 @@ export default {
   getTheadGroupThProps: emptyObj,
   getTheadProps: emptyObj,
   getTheadTrProps: emptyObj,
-  getTheadThProps: emptyObj,
+  getTheadThProps: ({ sorted }, rowInfo, column) => ({
+    sorted: sorted.find(col => col.id === column.id)
+  }),
   getTheadFilterProps: emptyObj,
   getTheadFilterTrProps: emptyObj,
   getTheadFilterThProps: emptyObj,


### PR DESCRIPTION
This pull request implements #485, by passing to every column header component its sorting state as a `sorted` prop in the default implementation of `getTheadThProps`. It is easier to render column headers depending on sorting. For example, augmenting the default `ThComponent`:

```javascript
const getIconClass = sorted => {
  if (sorted.desc === undefined) {
    return '';
  } else if (sorted.desc) {
    return '-desc';
  }
  return '-asc';
};

const ColumnHeader = ({ toggleSort, className, children, sorted, ...rest }) => (
  <div
    role='button'
    className={classNames(className, 'rt-th', 'wd-th')}
    onClick={e => {
      if (toggleSort) { toggleSort(e) }
    }}
    {...rest}
  >
    <div
      className={classNames('th-cell', { 'th-sorted': sorted.desc !== undefined })}
    >
      {children}
    </div>
    <div
      className={classNames('th-sort', { 'th-sorted': sorted.desc !== undefined })}
    >
      {
        <Icon
          name={
            `sort${getIconClass(sorted)}`
          }
          size='tiny'
        />
      }
    </div>
  </div>
);
```

The README is updated accordingly.