### PR TITLE
Fix ThComponent classnames ordering in defaultProps

### DIFF
--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -182,7 +182,7 @@ export default {
   TrComponent: _.makeTemplateComponent('rt-tr', 'Tr'),
   ThComponent: ({ toggleSort, className, children, ...rest }) => (
     <div
-      className={classnames(className, 'rt-th')}
+      className={classnames('rt-th', className)}
       onClick={e => (
         toggleSort && toggleSort(e)
       )}


### PR DESCRIPTION
This PR fixes a bug where the `ThComponent's` base class comes after the configurable class name. This prevents a user from customizing the styling of the header without using `!important` in their CSS. The change allows for a custom header classname to extend the base styles.