### PR TITLE
docs: add select HOC docs to better document how to use the HOC

### DIFF
--- a/src/hoc/README.md
+++ b/src/hoc/README.md
@@ -63,6 +63,11 @@ You include the HOC in the same manner as you would for the treeTableHOC but the
 - toggleSelection - called when the use clicks a specific checkbox/radio in a row
 - selectType - either `checkbox|radio` to indicate what type of selection is required
 
+**Note:** The select field defaults to the accessor `_id` property in order to render the select field for that particular row.  If your objects have different
+unique ID fields, make sure to tell React Table that by passing it the `keyField` property. 
+```Javascript
+<ReactTable keyField='id' />
+```
 In the case of `radio` there is no `selectAll` displayed but the developer is responsible for only making one selection in 
 the controlling component's state.  You could select multiple but it wouldn't make sense and you should use `checkbox` instead.
 


### PR DESCRIPTION
I ended up going thru the select table HOC source to figure out why non of my rows had a checkbox.  Turns out it assumes a default unique ID per row keyed as ._id and nothing mentions that at all.  So I figured I'd submit this in the hopes it can save someone else from having to do the same!  Let me know if you need anything changed or I just missed this being explained in the docs elsewhere.