### PR TITLE
Fix style prop not being properly used in ReactTablePagination component

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -68,7 +68,7 @@ export default class ReactTablePagination extends Component {
     return (
       <div
         className={classnames(className, '-pagination')}
-        style={this.props.paginationStyle}
+        style={this.props.style}
       >
         <div className="-previous">
           <PreviousComponent


### PR DESCRIPTION
It's passed as `style`, not `paginationStyle`

https://github.com/react-tools/react-table/blob/master/src/index.js#L943