### PR TITLE
Add prefix to key of pad rows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -827,7 +827,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
         getTrProps(finalState, undefined, undefined, this),
       )
       return (
-        <TrGroupComponent key={i} {...trGroupProps}>
+        <TrGroupComponent key={`pad-${i}`} {...trGroupProps}>
           <TrComponent
             className={classnames(
               '-padRow',


### PR DESCRIPTION
Add prefix to key of pad rows so it doesn't conflict with keys of page rows.
Duplicate keys are causing rendering issues with preact.
See #827 