### PR TITLE
fix(issue - 860) :  fix the 'No rows found' shown underneath 'Loading...' when loading is true and data is undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -991,7 +991,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
               {pagination}
             </div>
             : null}
-          {!pageRows.length &&
+          {!pageRows.length && !this.props.loading &&
             <NoDataComponent {...noDataProps}>
               {_.normalizeComponent(noDataText)}
             </NoDataComponent>}


### PR DESCRIPTION
 fix the 'No rows found' shown underneath 'Loading...' when loading is true and data is undefined