### PR TITLE
feat: added optional totalPages prop to React Table to manually set pages value

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ These are all of the available props (and their default values) for the main `<R
   // Controlled State Overrides (see Fully Controlled Component section)
   page: undefined,
   pageSize: undefined,
+  totalPages: undefined,
   sorted: [],
   filtered: [],
   resized: [],

--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -60,6 +60,7 @@ export default {
   // Controlled State Props
   // page: undefined,
   // pageSize: undefined,
+  // totalPages: undefined,
   // sorted: [],
   // filtered: [],
   // resized: [],

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import classnames from 'classnames'
-//
+
 import _ from './utils'
 import Lifecycle from './lifecycle'
 import Methods from './methods'
@@ -36,6 +36,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
     this.state = {
       page: 0,
       pageSize: props.defaultPageSize,
+      totalPages: props.totalPages,
       sorted: props.defaultSorted,
       expanded: props.defaultExpanded,
       filtered: props.defaultFiltered,
@@ -935,6 +936,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
         <PaginationComponent
           {...resolvedState}
           pages={pages}
+          totalPages={this.totalPages}
           canPrevious={canPrevious}
           canNext={canNext}
           onPageChange={this.onPageChange}

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react'
 import classnames from 'classnames'
-//
-// import _ from './utils'
 
 const defaultButton = props => (
   <button type="button" {...props} className="-btn">
@@ -56,6 +54,7 @@ export default class ReactTablePagination extends Component {
       showPageSizeOptions,
       pageSizeOptions,
       pageSize,
+      totalPages,
       showPageJump,
       canPrevious,
       canNext,
@@ -109,7 +108,9 @@ export default class ReactTablePagination extends Component {
                 {page + 1}
               </span>}{' '}
             {this.props.ofText}{' '}
-            <span className="-totalPages">{pages || 1}</span>
+            <span className="-totalPages">
+              {totalPages || (pages || 1)}
+            </span>
           </span>
           {showPageSizeOptions &&
             <span className="select-wrap -pageSizeOptions">


### PR DESCRIPTION
Implemented a `totalPages` prop on `ReactTable` which allows you to manually set the pages value in the Pagination section of the table (another controlled feature).

This new prop is optional, if it's value is undefined (falsey), then the table will continue to work as normal.