### PR TITLE
Added react-dom as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "react": "^15.x.x || ^16.x.x"
+    "react": "^15.x.x || ^16.x.x",
+    "react-dom": "^15.x.x || ^16.x.x"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.0",


### PR DESCRIPTION
Issue: https://github.com/facebook/react/issues/10320

<img width="655" alt="screen shot 2018-03-30 at 17 02 59" src="https://user-images.githubusercontent.com/20854139/38135661-5128f14a-3454-11e8-945f-48f3672d9966.png">

I've simply added `react-dom` as a peer dependency, which for some reason wasn't (but `react` is). This did solve the problem for my company's project codebase.

I don't know if some other internal compatibility issues might arise due to specific conditions that I cannot possibly test. I do hope  for full support of React v16 from the authors though.