### PR TITLE
Remove ellipsis from default expander table header

### DIFF
--- a/src/index.styl
+++ b/src/index.styl
@@ -123,6 +123,7 @@ input-select-style()
         border-right:0
     .rt-expandable
       cursor: pointer
+      text-overflow: clip
   .rt-tr-group
     flex: 1 0 auto
     display: flex


### PR DESCRIPTION
Addresses #862 and an unreported issue I've been seeing in Chrome. Just seems like a saner default to me.

Compare:

Before
![2018-04-19_14-30-52](https://user-images.githubusercontent.com/4165105/39011021-514acd94-43de-11e8-9e75-80b9e52781dc.png)

After
![2018-04-19_14-31-00](https://user-images.githubusercontent.com/4165105/39011027-54fd27d4-43de-11e8-9e7c-7b3cf00ba53a.png)

This is in Chrome on Linux (i3wm).
