### PR TITLE
Don't recalc page if in manual mode

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -103,7 +103,9 @@ export default Base =>
         newResolvedState.pages = newResolvedState.manual
           ? newResolvedState.pages
           : Math.ceil(newResolvedState.sortedData.length / newResolvedState.pageSize)
-        newResolvedState.page = Math.max(
+        newResolvedState.page = newResolvedState.manual
+          ? newResolvedState.page
+          : Math.max(
           newResolvedState.page >= newResolvedState.pages
             ? newResolvedState.pages - 1
             : newResolvedState.page,


### PR DESCRIPTION
Add 'manual' check for page recalc to be consistent with pages.
Allows page prop setting to stick when # of pages is unknown.

Enables this:
https://gist.github.com/TimNZ/83631516f3e7a1ca1be33228bc3d56d6