### PR TITLE
Add more documentation for overriding props

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ These are all of the available props (and their default values) for the main `<R
   getResizerProps: () => ({}),
 
   // Global Column Defaults
+  // To override only some values, import { ReactTableDefaults } from 'react-table'
+  // and construct your overrides (e.g. {...ReactTableDefaults.column, className: 'react-table-cell'})
   column: {
     // Renderers
     Cell: undefined,
@@ -312,6 +314,8 @@ These are all of the available props (and their default values) for the main `<R
   },
 
   // Global Expander Column Defaults
+  // To override only some values, import { ReactTableDefaults } from 'react-table'
+  // and construct your overrides (e.g. {...ReactTableDefaults.expanderDefaults, sortable: true})
   expanderDefaults: {
     sortable: false,
     resizable: false,


### PR DESCRIPTION
I think this is the most common way of setting columns or expanderDefaults.

I had to find issue #565 and then follow it to issue #394 to see explanations on how to do this.