### PR TITLE
Fix propTypes validation for getFooterProps

### DIFF
--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -114,7 +114,7 @@ export default {
       // Footers only
       footerClassName: PropTypes.string,
       footerStyle: PropTypes.object,
-      getFooterProps: PropTypes.object,
+      getFooterProps: PropTypes.func,
       filterMethod: PropTypes.func,
       filterAll: PropTypes.bool,
       sortMethod: PropTypes.func,


### PR DESCRIPTION
The prop type for `getFooterProps` is currently `PropTypes.object`, but `getFooterProps` (like all of the other `getXProps` props) should be a function. Providing a function for this prop works as expected but throws a PropType validation error.

This change updates the type to `PropTypes.func` to match the other `getXProps` props.