### PR TITLE
Tree uses accessor or ID and always shows pivot cells

### DIFF
--- a/src/hoc/treeTable/index.js
+++ b/src/hoc/treeTable/index.js
@@ -51,6 +51,7 @@ export default Component => {
           let column = col
           if (rest.pivotBy && (rest.pivotBy.includes(col.accessor) || rest.pivotBy.includes(col.id))) {
             column = {
+              id: col.id,
               accessor: col.accessor,
               width: `${treeTableIndent}px`,
               show: false,

--- a/src/hoc/treeTable/index.js
+++ b/src/hoc/treeTable/index.js
@@ -49,7 +49,7 @@ export default Component => {
       const extra = {
         columns: columns.map(col => {
           let column = col
-          if (rest.pivotBy && rest.pivotBy.includes(col.accessor)) {
+          if (rest.pivotBy && (rest.pivotBy.includes(col.accessor) || rest.pivotBy.includes(col.id))) {
             column = {
               accessor: col.accessor,
               width: `${treeTableIndent}px`,

--- a/src/index.js
+++ b/src/index.js
@@ -643,7 +643,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
                   key={`${i2}-${column.id}`}
                   className={classnames(
                     classes,
-                    !show && 'hidden',
+                    !cellInfo.expandable && !show && 'hidden',
                     cellInfo.expandable && 'rt-expandable',
                     (isBranch || isPreview) && 'rt-pivot'
                   )}


### PR DESCRIPTION
This should allow people using the `treeTableHOC` to use an `id` instead of an `accessor` to reference the pivoted field.

Also, it seems to me that an expandable cell should never be hidden.  The `treeTableHOC` code adds a `show: false` to both the subrows _and_ the expandable rows.  Not sure where I'm enforcing that was the right place, but it seems to be the issue experienced by these users:

https://github.com/react-tools/react-table/issues/891
https://github.com/react-tools/react-table/issues/930