### PR TITLE
SelectTable - Make input component type defaults to checkbox

### DIFF
--- a/src/hoc/selectTable/index.js
+++ b/src/hoc/selectTable/index.js
@@ -106,7 +106,7 @@ export default Component => {
     toggleAll: () => {
       console.log('No toggleAll handler provided.')
     },
-    selectType: 'check',
+    selectType: 'checkbox',
     SelectInputComponent: defaultSelectInputComponent,
     SelectAllInputComponent: defaultSelectInputComponent,
   }


### PR DESCRIPTION
Fix for [#1020](https://github.com/react-tools/react-table/issues/1020)