### PR TITLE
Add additional column's renderers in TreeTable HOC

### DIFF
--- a/src/hoc/treeTable/index.js
+++ b/src/hoc/treeTable/index.js
@@ -55,6 +55,9 @@ export default Component => {
               width: `${treeTableIndent}px`,
               show: false,
               Header: '',
+              Expander: col.Expander,
+              PivotValue: col.PivotValue,
+              Pivot: col.Pivot,
             }
           }
           return column


### PR DESCRIPTION
Pass Expander, PivotValue and Pivot renderers to column builder in TreeTable HOC.