### PR TITLE
Resolves TypeError when rendering class components Renderers and Filters 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -205,11 +205,7 @@ function isSortingDesc (d) {
 
 function normalizeComponent (Comp, params = {}, fallback = Comp) {
   return typeof Comp === 'function' ? (
-    Object.getPrototypeOf(Comp).isReactComponent ? (
-      <Comp {...params} />
-    ) : (
-      Comp(params)
-    )
+    <Comp {...params} />
   ) : (
     fallback
   )


### PR DESCRIPTION
### Summary

Given a class component as a Renderer or Filter, react-table throws an error `TypeError: Cannot call a class as a function` instead of rendering the component. This appears to be because the util is using `isReactComponent` to check whether an object is a component, which I believe was an implementation detail from the old `React.createClass` days and isn't defined in modern class components.

### Issue

Renderers: (`{ Cell: MyCell }`)
```jsx
// functional component, works
const MyCell = props => props.value

// class component, throws
class MyCell extends React.Component { 
  render() {
    return this.props.value
  }
}
```

Filters: (`{ Filter: MyFilter }`)
```jsx
// works
const MyFilter = ({ filter, onChange }) => (
  <input 
    value={filter ? filter.value : ''} 
    onChange={e => onChange(e.target.value)} 
  />
)

// throws
class MyFilter extends React.Component {
  handleChange = e => {
    this.props.onChange(e.target.value)
  }

  render() {
    const {filter} = this.props
    return (
      <input 
        value={filter ? filter.value : ''} 
        onChange={this.handleChange} 
      />
    )
  }
}
```

### Resolution

It appears that the `normalizeComponent` checks for `isReactComponent` on the prototype, which is not a viable way to check if an object is a React Class Component. I removed the check because the JSX style can render either functional or class components.