### PR TITLE
Adds "prop-types" as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "prop-types": "^15.5.0",
     "react": "^15.x.x || ^16.x.x",
-    "react-dom": "^15.x.x || ^16.x.x",
+    "react-dom": "^15.x.x || ^16.x.x"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,9 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
+    "prop-types": "^15.5.0",
     "react": "^15.x.x || ^16.x.x",
-    "react-dom": "^15.x.x || ^16.x.x"
+    "react-dom": "^15.x.x || ^16.x.x",
   },
   "devDependencies": {
     "autoprefixer": "^6.7.0",


### PR DESCRIPTION
`react-table` uses `prop-types` in its source and hence including it as a peer dependency makes sense. Also, this helps analysis tools like bundlephobia.com determine external packages.