### PR TITLE
Bugfix: Pagination component: Only update page state if page prop actually changes

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -23,7 +23,9 @@ export default class ReactTablePagination extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    this.setState({ page: nextProps.page })
+    if (this.props.page !== nextProps.page) {
+      this.setState({ page: nextProps.page })
+    }
   }
 
   getSafePage (page) {


### PR DESCRIPTION
Had some issues using the pagination component as the page number would always reset in response to any prop change