### PR TITLE
Feature - Option to display filters above headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ These are all of the available props (and their default values) for the main `<R
   multiSort: true,
   resizable: true,
   filterable: false,
+  showFiltersAbove: false,
   defaultSortDesc: false,
   defaultSorted: [],
   defaultFiltered: [],

--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -27,6 +27,7 @@ export default {
   multiSort: true,
   resizable: true,
   filterable: false,
+  showFiltersAbove: false,
   defaultSortDesc: false,
   defaultSorted: [],
   defaultFiltered: [],

--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
       multiSort,
       resizable,
       filterable,
+      showFiltersAbove,
       // Pivoting State
       pivotIDKey,
       pivotValKey,
@@ -831,9 +832,10 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
             style={tableProps.style}
             {...tableProps.rest}
           >
+            {hasFilters && showFiltersAbove ? makeFilters() : null}
             {hasHeaderGroups ? makeHeaderGroups() : null}
             {makeHeaders()}
-            {hasFilters ? makeFilters() : null}
+            {hasFilters && !showFiltersAbove ? makeFilters() : null}
             <TbodyComponent
               className={classnames(tBodyProps.className)}
               style={{

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -18,6 +18,7 @@ export default {
   sortable: PropTypes.bool,
   resizable: PropTypes.bool,
   filterable: PropTypes.bool,
+  showFiltersAbove: PropTypes.bool,
   defaultSortDesc: PropTypes.bool,
   defaultSorted: PropTypes.array,
   defaultFiltered: PropTypes.array,


### PR DESCRIPTION
Use Case
---------

The current filtering system, while being pretty robust, is not flexible enough to enable certain UX desires. 

For instance it is not possible to display the filters above the table head in such way:
![image](https://user-images.githubusercontent.com/13723209/44889576-c07ceb80-ad19-11e8-8e73-b238a23f86a2.png)

I currently achieved it with some CSS hacks:
```
.ReactTable {
    padding-top: 4em;
}
.ReactTable .rt-thead.-filters {
    position: absolute;
    top: 0;
    border-bottom: none;
    width: 100%;
}
```
But this has proven to be unreliable (if a filter has a dynamic height, it overflows to the table, and not to mention z-index issues with position absolutes.)

Solution
---------
This PR adds a new ReactTable prop `showFiltersAbove`, if set to true, will display the filter rows above the table headers.

And the following becomes possible:
![image](https://user-images.githubusercontent.com/13723209/44889740-a8f23280-ad1a-11e8-9f8f-17c507708161.png)

Which then can easily be styled to look like:
![image](https://user-images.githubusercontent.com/13723209/44889987-a9d79400-ad1b-11e8-9bf7-c3357e97de03.png)

