### PR TITLE
Use pivot value for nesting path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -471,7 +471,7 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
         pageSize,
         page,
         level: path.length,
-        nestingPath: path.concat([i]),
+        nestingPath: path.concat([row[pivotValKey] ? row[pivotValKey] : i]),
         aggregated: row[aggregatedKey],
         groupedByPivot: row[groupedByPivotKey],
         subRows: row[subRowsKey],


### PR DESCRIPTION
This would be really helpful so we can store expanded row preferences based on row data and not on row index which can change with sorting.