### PR TITLE
Fixed defaultProps.selectType.

### DIFF
--- a/src/hoc/selectTable/index.js
+++ b/src/hoc/selectTable/index.js
@@ -106,7 +106,7 @@ export default Component => {
     toggleAll: () => {
       console.log('No toggleAll handler provided.')
     },
-    selectType: 'check',
+    selectType: 'checkbox',
     SelectInputComponent: defaultSelectInputComponent,
     SelectAllInputComponent: defaultSelectInputComponent,
   }


### PR DESCRIPTION
Changed defaultProps.selectType from "check" to "checkbox".

While working with react-table for my first time (aiming to replace an overly-complicated table solution at work), I found that by default the selectTable HOC component gave me an input for the checkbox, which I found to be quite odd.

Here is a screenshot and a CodeSandbox demonstrating how I ran into this issue:

https://codesandbox.io/s/z3ylko96pp

![react-table](https://user-images.githubusercontent.com/19484365/45580247-d7582d80-b843-11e8-80ce-9910ef6feb10.PNG)

I found that defaultProps.selectType (on the selectTable HOC) was set to "check", which is an invalid value to be passed to an `<input>` element in the `type` attribute. I changed it to "checkbox" in this PR.

Here is a screenshot using the correct "checkbox" value:

![react-table-0](https://user-images.githubusercontent.com/19484365/45580300-6e24ea00-b844-11e8-9e1e-64122f4d198a.PNG)


Let me know if "check" and the text-input behavior was intended. :+1: