### PR TITLE
feature: allow minResizeWidth to be set

### DIFF
--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -134,6 +134,7 @@ export default {
     filterable: undefined, // use table default
     show: true,
     minWidth: 100,
+    minResizeWidth: 11,
     // Cells only
     className: '',
     style: {},

--- a/src/methods.js
+++ b/src/methods.js
@@ -616,8 +616,10 @@ export default Base =>
 
     resizeColumnMoving (event) {
       event.stopPropagation()
-      const { onResizedChange } = this.props
-      const { resized, currentlyResizing } = this.getResolvedState()
+      const { onResizedChange, column } = this.props
+      const { resized, currentlyResizing, columns } = this.getResolvedState()
+      const currentColumn = columns.find(c => c.accessor === currentlyResizing.id);
+      const minResizeWidth = currentColumn ? currentColumn.minResizeWidth : column.minResizeWidth;
 
       // Delete old value
       const newResized = resized.filter(x => x.id !== currentlyResizing.id)
@@ -630,11 +632,9 @@ export default Base =>
         pageX = event.pageX
       }
 
-      // Set the min size to 10 to account for margin and border or else the
-      // group headers don't line up correctly
       const newWidth = Math.max(
         currentlyResizing.parentWidth + pageX - currentlyResizing.startX,
-        11
+        minResizeWidth
       )
 
       newResized.push({

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -97,6 +97,7 @@ export default {
       filterable: PropTypes.bool, // use table default
       show: PropTypes.bool,
       minWidth: PropTypes.number,
+      minResizeWidth: PropTypes.number,
 
       // Cells only
       className: PropTypes.string,
@@ -117,7 +118,7 @@ export default {
       getFooterProps: PropTypes.object,
       filterMethod: PropTypes.func,
       filterAll: PropTypes.bool,
-      sortMethod: PropTypes.func,
+      sortMethod: PropTypes.func
     })
   ),
 
@@ -126,7 +127,7 @@ export default {
     sortable: PropTypes.bool,
     resizable: PropTypes.bool,
     filterable: PropTypes.bool,
-    width: PropTypes.number,
+    width: PropTypes.number
   }),
 
   pivotDefaults: PropTypes.object,
@@ -162,5 +163,5 @@ export default {
   LoadingComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
   NoDataComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
   ResizerComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
-  PadRowComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
+  PadRowComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.element])
 }


### PR DESCRIPTION
This PR implements the `minResize`-Prop which specifies to what minimum width a column can be resized.

I found [this](https://github.com/react-tools/react-table/issues/536#issuecomment-334904841) issue where @gary-menzel mentions something like this. I found this after I added the functionality.

Please review this PR and suggest changes. As of now the functionality is in place and satisfying my current needs. I would like to see this in the main repo otherwise I will have to use my fork from now on.