### PR TITLE
Updated ReadMe with some more Props

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,9 @@ Every single built-in component's props can be dynamically extended using any on
   getTheadProps={fn}
   getTheadTrProps={fn}
   getTheadThProps={fn}
+  getTheadFilterProps={fn}
+  getTheadFilterTrProps={fn}
+  getTheadFilterThProps={fn}
   getTbodyProps={fn}
   getTrGroupProps={fn}
   getTrProps={fn}


### PR DESCRIPTION
I found the added Props by looking into the defaultProps.js when I could not find a way change the styling of the filter row.
Custom Props
Built-in Components
Every single built-in component's props can be dynamically extended using any one of these prop-callbacks:

<ReactTable
  getProps={fn}
  getTableProps={fn}
  getTheadGroupProps={fn}
  getTheadGroupTrProps={fn}
  getTheadGroupThProps={fn}
  getTheadProps={fn}
  getTheadTrProps={fn}
  getTheadThProps={fn}
  +getTheadFilterProps={fn}
  +getTheadFilterTrProps={fn}
  +getTheadFilterThProps={fn}