### PR TITLE
Example code fixed with missing return statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ render() {
     accessor: 'friend.age'
   }]
 
-  <ReactTable
+  return <ReactTable
     data={data}
     columns={columns}
   />


### PR DESCRIPTION
Javascript has no implicit return. Needs the statement. Added it to the example.