### PR TITLE
Adds aria-label prop to checkboxes

### DIFF
--- a/src/hoc/selectTable/index.js
+++ b/src/hoc/selectTable/index.js
@@ -6,6 +6,7 @@ const defaultSelectInputComponent = props => {
   return (
     <input
       type={props.selectType || 'checkbox'}
+      aria-label={`${props.checked ? 'Un-select':'Select'} row with id:${props.id}` }
       checked={props.checked}
       onClick={e => {
         const { shiftKey } = e


### PR DESCRIPTION
This is a small change to add an 'aria-label' attribute to each checkbox in selectTable HOC. Text of label is dynamically generated from other row props.