### PR TITLE
Improving the pivot functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-table",
-  "version": "6.8.2",
+  "version": "6.8.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1798,17 +1798,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "create-react-class": {
-      "version": "15.6.3",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-      "dev": true,
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
     },
     "cross-env": {
       "version": "5.1.4",
@@ -5777,16 +5766,27 @@
       }
     },
     "react": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "version": "16.6.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+      "integrity": "sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==",
       "dev": true,
       "requires": {
-        "create-react-class": "15.6.3",
-        "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.1"
+        "prop-types": "15.6.2",
+        "scheduler": "0.11.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
     "react-base16-styling": {
@@ -5802,15 +5802,27 @@
       }
     },
     "react-dom": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
-      "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+      "version": "16.6.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+      "integrity": "sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.1"
+        "prop-types": "15.6.2",
+        "scheduler": "0.11.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
     "react-json-tree": {
@@ -6870,6 +6882,16 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
       "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
+      "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
     },
     "semver": {
       "version": "4.3.6",

--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -75,6 +75,10 @@ export default {
 
   // Pivoting
   pivotBy: undefined,
+  pivotConfig: {
+    hideSingleRowExpander: false,
+    allowPivotExpanderCol: false,
+  },
 
   // Key Constants
   pivotValKey: '_pivotVal',

--- a/src/index.js
+++ b/src/index.js
@@ -84,9 +84,10 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
       resizable,
       filterable,
       // Pivoting State
+      pivotBy,
+      pivotConfig,
       pivotIDKey,
       pivotValKey,
-      pivotBy,
       subRowsKey,
       aggregatedKey,
       originalKey,
@@ -541,6 +542,9 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
                 )
               }
 
+              ///check if this row has one or less subrows. This is used to decide to add and render the expander function.
+              const hasOneOrLessSubRows = cellInfo.subRows && cellInfo.subRows.length <= 1
+
               // Default to a standard cell
               let resolvedCell = _.normalizeComponent(column.Cell, cellInfo, value)
 
@@ -569,6 +573,11 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
                 if (cellInfo.pivoted && !cellInfo.subRows && !SubComponent) {
                   cellInfo.expandable = false
                 }
+                ///If pivoted and hideSingleRowExpander=true and has only one subRow, do not make expandable
+                if (cellInfo.pivoted && pivotConfig.hideSingleRowExpander && hasOneOrLessSubRows) {
+                  cellInfo.expandable = false
+                  useOnExpanderClick = false
+                } 
               }
 
               if (cellInfo.pivoted) {
@@ -606,7 +615,10 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
                   row[pivotValKey]
                 )
                 if (pivotBy) {
-                  if (cellInfo.groupedByPivot) {
+                  if (cellInfo.groupedByPivot && !pivotConfig.allowPivotExpanderCol) {
+                    resolvedCell = null
+                  }
+                  if (pivotConfig.hideSingleRowExpander && hasOneOrLessSubRows) {
                     resolvedCell = null
                   }
                   if (!cellInfo.subRows && !SubComponent) {


### PR DESCRIPTION
Here are two additions that I need for my use case:

- Adds "hideSingleRowExpander"-option to remove the expander for pivoted columns that have only one subRow. 
- Adding an option "allowPivotExpanderCol" to allow a pivot expander in a separate expander Column.

I would be happy if they would make it into the repo. Feel free to tell me if these changes do not fit the project ore are poorly executed, or can be solved without changing react-table at all. I am willing to learn and also change the additions.

Here is a showcase:
https://codesandbox.io/s/8lw1y6xxm2

I accidentally used a different account in my IDE, therefor the commit comes from a different user (which is also me :D )

|3ig|3uilder