### PR TITLE
update fireFetchData to use current state for select value

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -331,7 +331,15 @@ export default Base =>
     }
 
     fireFetchData () {
-      this.props.onFetchData(this.getResolvedState(), this)
+      // determine the current state, preferring certain state values over props
+      const currentState = {
+        ...this.getResolvedState(),
+        page: this.getStateOrProp('page'),
+        pageSize: this.getStateOrProp('pageSize'),
+        filter: this.getStateOrProp('filter'),
+      };
+
+      this.props.onFetchData(currentState, this)
     }
 
     getPropOrState (key) {


### PR DESCRIPTION
Fixes #1230 -- needs review.

When firing fetch data, react-table needs to send the current values for `page`, `pageSize`, and `filter` (and perhaps other values as well but these were the most obvious. For manual tables, when setting state in the handler for `onFetchData`, the end user needs to pass the props back to the react-table instance in order to keep everything in sync.